### PR TITLE
Add background color modifier to ASCollectionView

### DIFF
--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -67,6 +67,14 @@ public extension ASCollectionView
 		return this
 	}
 
+    /// Sets the collection view's background color
+    func backgroundColor(_ color: UIColor?) -> Self
+    {
+        var this = self
+        this.backgroundColor = color
+        return this
+    }
+
 	/// Set whether to show scroll indicators
 	func scrollIndicatorsEnabled(horizontal: Bool = true, vertical: Bool = true) -> Self
 	{

--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -67,13 +67,13 @@ public extension ASCollectionView
 		return this
 	}
 
-    /// Sets the collection view's background color
-    func backgroundColor(_ color: UIColor?) -> Self
-    {
-        var this = self
-        this.backgroundColor = color
-        return this
-    }
+	/// Sets the collection view's background color
+	func backgroundColor(_ color: UIColor?) -> Self
+	{
+		var this = self
+		this.backgroundColor = color
+		return this
+	}
 
 	/// Set whether to show scroll indicators
 	func scrollIndicatorsEnabled(horizontal: Bool = true, vertical: Bool = true) -> Self

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -25,8 +25,10 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 	internal var contentSizeTracker: ContentSizeTracker?
 
-	internal var onScrollCallback: OnScrollCallback?
-	internal var onReachedBoundaryCallback: OnReachedBoundaryCallback?
+    internal var onScrollCallback: OnScrollCallback?
+    internal var onReachedBoundaryCallback: OnReachedBoundaryCallback?
+
+    internal var backgroundColor: UIColor?
 
 	internal var horizontalScrollIndicatorEnabled: Bool = true
 	internal var verticalScrollIndicatorEnabled: Bool = true
@@ -184,6 +186,7 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 		func updateCollectionViewSettings(_ collectionView: UICollectionView)
 		{
+            assignIfChanged(collectionView, \.backgroundColor, newValue: parent.backgroundColor)
 			assignIfChanged(collectionView, \.dragInteractionEnabled, newValue: true)
 			assignIfChanged(collectionView, \.alwaysBounceVertical, newValue: parent.alwaysBounceVertical)
 			assignIfChanged(collectionView, \.alwaysBounceHorizontal, newValue: parent.alwaysBounceHorizontal)

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -25,10 +25,10 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 	internal var contentSizeTracker: ContentSizeTracker?
 
-    internal var onScrollCallback: OnScrollCallback?
-    internal var onReachedBoundaryCallback: OnReachedBoundaryCallback?
+	internal var onScrollCallback: OnScrollCallback?
+	internal var onReachedBoundaryCallback: OnReachedBoundaryCallback?
 
-    internal var backgroundColor: UIColor?
+	internal var backgroundColor: UIColor?
 
 	internal var horizontalScrollIndicatorEnabled: Bool = true
 	internal var verticalScrollIndicatorEnabled: Bool = true


### PR DESCRIPTION
This pull request adds a `backgroundColor()` modifier to `ASCollectionView`. This is intended to solve the problem of not being able to add a background color via SwiftUI to `ASCollectionView` without breaking the built-in large title navigation bar behavior.