### PR TITLE
Add selection modifiers to ASCollectionView

### DIFF
--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -140,6 +140,22 @@ public extension ASCollectionView
 		this.maintainScrollPositionOnOrientationChange = true
 		return this
 	}
+
+	/// Sets whether the ASCollectionView should allow selection, default is true
+	func allowsSelection(_ allowsSelection: Bool) -> Self
+	{
+		var this = self
+		this.allowsSelection = allowsSelection
+		return this
+	}
+
+	/// Sets whether the ASCollectionView should allow multiple selection, default is false
+	func allowsMultipleSelection(_ allowsMultipleSelection: Bool) -> Self
+	{
+		var this = self
+		this.allowsMultipleSelection = allowsMultipleSelection
+		return this
+	}
 }
 
 // MARK: PUBLIC layout modifier functions

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -53,6 +53,9 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 	internal var dodgeKeyboard: Bool = true
 
+	internal var allowsSelection: Bool = true
+	internal var allowsMultipleSelection: Bool = false
+
 	// MARK: Environment variables
 
 	// SwiftUI environment
@@ -196,8 +199,8 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 			updateCollectionViewContentInsets(collectionView)
 
 			let isEditing = parent.editMode?.wrappedValue.isEditing ?? false
-			assignIfChanged(collectionView, \.allowsSelection, newValue: isEditing)
-			assignIfChanged(collectionView, \.allowsMultipleSelection, newValue: isEditing)
+			assignIfChanged(collectionView, \.allowsSelection, newValue: parent.allowsSelection || isEditing)
+			assignIfChanged(collectionView, \.allowsMultipleSelection, newValue: parent.allowsMultipleSelection || isEditing)
 		}
 
 		func updateCollectionViewContentInsets(_ collectionView: UICollectionView)


### PR DESCRIPTION
This pull request makes it possible to use `UICollectionView`'s normal item selection outside of an editing context. This is useful when selecting a collection view item changes "global" view state. A common example is when selecting an item shows a modal sheet. It's possible to do this now by adding touch handling directly to the item views themselves, but that creates problems when trying enforce invariants like limiting the app to one visible sheet at a time.