### PR TITLE
Improve selection

### DIFF
--- a/Demo/ASCollectionViewDemo.xcodeproj/project.pbxproj
+++ b/Demo/ASCollectionViewDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5708D2572504FCC50014C671 /* OnChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708D2562504FCC50014C671 /* OnChange.swift */; };
 		B8268B522363EF03008C99A3 /* RemindersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8268B512363EF03008C99A3 /* RemindersScreen.swift */; };
 		B8268B542363EF1B008C99A3 /* GroupLarge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8268B532363EF1B008C99A3 /* GroupLarge.swift */; };
 		B8268B562363EF25008C99A3 /* GroupSmall.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8268B552363EF25008C99A3 /* GroupSmall.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5708D2562504FCC50014C671 /* OnChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChange.swift; sourceTree = "<group>"; };
 		B8268B512363EF03008C99A3 /* RemindersScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemindersScreen.swift; sourceTree = "<group>"; };
 		B8268B532363EF1B008C99A3 /* GroupLarge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupLarge.swift; sourceTree = "<group>"; };
 		B8268B552363EF25008C99A3 /* GroupSmall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSmall.swift; sourceTree = "<group>"; };
@@ -158,10 +160,11 @@
 		B86C6F30234B0B9D00522AEF /* Support */ = {
 			isa = PBXGroup;
 			children = (
-				B86C6F31234B0B9D00522AEF /* ASRemoteImageView.swift */,
 				B86C6F32234B0B9D00522AEF /* ASCache.swift */,
 				B86C6F33234B0B9D00522AEF /* ASRemoteImageManager.swift */,
+				B86C6F31234B0B9D00522AEF /* ASRemoteImageView.swift */,
 				B86C6F34234B0B9D00522AEF /* LoremSwiftum.swift */,
+				5708D2562504FCC50014C671 /* OnChange.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 			files = (
 				B8C00A972376350B0066348C /* AdjustableGridScreen.swift in Sources */,
 				B8268B542363EF1B008C99A3 /* GroupLarge.swift in Sources */,
+				5708D2572504FCC50014C671 /* OnChange.swift in Sources */,
 				B86C6F44234B0B9D00522AEF /* ASCache.swift in Sources */,
 				B86C6F4B234B0B9D00522AEF /* AppViews.swift in Sources */,
 				B89129FE235DB71900D8BA90 /* TagsScreen.swift in Sources */,

--- a/Demo/ASCollectionViewDemo/Support/OnChange.swift
+++ b/Demo/ASCollectionViewDemo/Support/OnChange.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+extension View
+{
+	func onChange<V: Equatable>(of value: V, perform action: @escaping (V) -> Void) -> some View
+	{
+		OnChange(content: self, value: value, perform: action)
+	}
+}
+
+// `View.onChange(of:perform:)` is only available on iOS 14.0+
+// https://developer.apple.com/documentation/swiftui/view/onchange(of:perform:)
+private struct OnChange<Content: View, V: Equatable>: View
+{
+	private let content: Content
+	private let current: V
+	private let action: (V) -> Void
+
+	@State private var state: ValueState<V>
+
+	init(content: Content, value: V, perform action: @escaping (V) -> Void)
+	{
+		self.content = content
+		current = value
+		self.action = action
+		_state = .init(initialValue: ValueState(value))
+	}
+
+	var body: some View
+	{
+		if state.didChange(current)
+		{
+			DispatchQueue.main.async
+			{
+				self.action(self.current)
+			}
+		}
+		return content
+	}
+}
+
+private final class ValueState<V: Equatable>
+{
+	private var current: V
+
+	init(_ value: V)
+	{
+		current = value
+	}
+
+	func didChange(_ new: V) -> Bool
+	{
+		guard new != current else { return false }
+		current = new
+		return true
+	}
+}

--- a/Sources/ASCollectionView/Delegate/ASCollectionViewDelegate.swift
+++ b/Sources/ASCollectionView/Delegate/ASCollectionViewDelegate.swift
@@ -49,6 +49,14 @@ open class ASCollectionViewDelegate: NSObject, UICollectionViewDelegate, UIColle
 		coordinator?.collectionView(collectionView, didEndDisplayingSupplementaryView: view, forElementOfKind: elementKind, at: indexPath)
 	}
 
+	open func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+		coordinator?.collectionView(collectionView, shouldSelectItemAt: indexPath) ?? true
+	}
+
+	open func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
+		coordinator?.collectionView(collectionView, shouldDeselectItemAt: indexPath) ?? true
+	}
+
 	open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath)
 	{
 		coordinator?.collectionView(collectionView, didSelectItemAt: indexPath)

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -663,20 +663,22 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 		public func collectionView(_ collectionView: UICollectionView, willSelectItemAt indexPath: IndexPath) -> IndexPath?
 		{
-			guard parent.sections[safe: indexPath.section]?.dataSource.shouldSelect(indexPath) ?? true else
-			{
-				return nil
-			}
-			return indexPath
+			self.collectionView(collectionView, shouldSelectItemAt: indexPath) ? indexPath : nil
 		}
 
 		public func collectionView(_ collectionView: UICollectionView, willDeselectItemAt indexPath: IndexPath) -> IndexPath?
 		{
-			guard parent.sections[safe: indexPath.section]?.dataSource.shouldDeselect(indexPath) ?? true else
-			{
-				return nil
-			}
-			return indexPath
+			self.collectionView(collectionView, shouldDeselectItemAt: indexPath) ? indexPath : nil
+		}
+
+		public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool
+		{
+			parent.sections[safe: indexPath.section]?.dataSource.shouldSelect(indexPath) ?? true
+		}
+
+		public func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool
+		{
+			parent.sections[safe: indexPath.section]?.dataSource.shouldDeselect(indexPath) ?? true
 		}
 
 		public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath)
@@ -715,7 +717,8 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 		private func threeWayMerge(base: Set<IndexPath>, dataSource: Set<IndexPath>, collectionView: Set<IndexPath>) -> Set<IndexPath>
 		{
-			base == dataSource ? collectionView : dataSource
+			// In case the data source and collection view are both different from base, default to the collection view
+			base == collectionView ? dataSource : collectionView
 		}
 
 		private func selectionDifferences(oldSelectedIndexPaths: Set<IndexPath>, newSelectedIndexPaths: Set<IndexPath>) -> (toDeselect: Set<IndexPath>, toSelect: Set<IndexPath>)
@@ -967,6 +970,8 @@ internal protocol ASCollectionViewCoordinator: AnyObject
 	func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath)
 	func collectionView(_ collectionView: UICollectionView, willDisplaySupplementaryView view: UICollectionReusableView, forElementKind elementKind: String, at indexPath: IndexPath)
 	func collectionView(_ collectionView: UICollectionView, didEndDisplayingSupplementaryView view: UICollectionReusableView, forElementOfKind elementKind: String, at indexPath: IndexPath)
+	func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool
+	func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool
 	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath)
 	func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath)
 	func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration?


### PR DESCRIPTION
This pull requests makes a few improvements to the `ASCollectionView`'s selection handling.

* Fix a selection bug in which changing single selection didn't work because, on conflict, we weren't defaulting to the collection view's selection
* Add support for preventing selection/deselection for specific indexes in a section
* Update Waterfall layout example to add a sheet detail view